### PR TITLE
Add a publish-to-PyPi GA

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,16 @@
+name: 'Publish to PyPI'
+
+on:
+  release:
+    types: [ 'released' ]
+
+jobs:
+  publish:
+    uses: 'spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@main'
+    with:
+      test: false
+      build_platform_wheels: false # Set to true if your package contains a C extension
+    secrets:
+      user: '${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}'
+      password: '${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}' # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
+      test_password: '${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     {name = "John Glorioso", email = "jglorioso@stsci.edu"},
 ]
 description = "Standardized logging for metrics capture for applications with requirements."
-readme = { file = "README.md", content-type = "text/x-rst" }
+readme = { file = "README.md", content-type = "text/plain" }
 requires-python = ">=3.9"
 dependencies = ["pytest"]
 dynamic = ["version"]


### PR DESCRIPTION
This PR adds a GA to publish Github releases to PyPi.