### PR TITLE
upload to codecov with their provided action

### DIFF
--- a/.github/workflows/metrics_logger_ci.yml
+++ b/.github/workflows/metrics_logger_ci.yml
@@ -26,9 +26,14 @@ jobs:
           auto-activate-base: false
       - name: Run tests
         run: |
-          pytest --cache-clear --cov=src/ --cov-report term-missing tests/ > pytest-coverage.txt
+          pytest --cache-clear --cov=src/ --cov-report term-missing --cov-report xml:coverage.xml tests/ > pytest-coverage.txt
       - name: Echo failing test results
         if: failure()
         run: cat pytest-coverage.txt
       - name: Pytest Coverage Commenatator
         uses: coroo/pytest-coverage-commentator@v1.0.2
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      

--- a/.github/workflows/metrics_logger_ci.yml
+++ b/.github/workflows/metrics_logger_ci.yml
@@ -24,14 +24,7 @@ jobs:
           environment-file: conda-env.yml
           activate-environment: metrics-logger
           auto-activate-base: false
-      - name: Run tests
-        run: |
-          pytest --cache-clear --cov=src/ --cov-report term-missing --cov-report xml:coverage.xml tests/ > pytest-coverage.txt
-      - name: Echo failing test results
-        if: failure()
-        run: cat pytest-coverage.txt
-      - name: Pytest Coverage Commenatator
-        uses: coroo/pytest-coverage-commentator@v1.0.2
+      - run: pytest --cache-clear --cov=src/ --cov-report term-missing --cov-report xml:coverage.xml tests/
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![CI](https://github.com/spacetelescope/metrics_logger/actions/workflows/metrics_logger_ci.yml/badge.svg)](https://github.com/spacetelescope/metrics_logger/actions/workflows/metrics_logger_ci.yml)
 [![Powered by STScI Badge](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
+[![codecov](https://codecov.io/gh/spacetelescope/metrics_logger/graph/badge.svg?token=hGkFbpjWBk)](https://codecov.io/gh/spacetelescope/metrics_logger)
 
 The metrics logger is a simple decorator intended to provide standardized logging for annotated pytest methods with tags to identify associated build requirements. As this is a generic utility, any method can be decorated and any type of tagging can be provided.
 


### PR DESCRIPTION
we can upload coverage to CodeCov with their action

To set it up, someone with admin access should add the repository secret under the Settings tab by following these instructions: https://app.codecov.io/gh/spacetelescope/metrics_logger/new

I can also do it if you give me permissions.