### PR TITLE
Fix name of branch

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,7 +6,11 @@ on:
 
 jobs:
   publish:
+<<<<<<< HEAD
     uses: 'spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@main'
+=======
+    uses: 'spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master'
+>>>>>>> df49cc6... fix branch of GA
     with:
       test: false
       build_platform_wheels: false # Set to true if your package contains a C extension

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,11 +6,7 @@ on:
 
 jobs:
   publish:
-<<<<<<< HEAD
-    uses: 'spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@main'
-=======
     uses: 'spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master'
->>>>>>> df49cc6... fix branch of GA
     with:
       test: false
       build_platform_wheels: false # Set to true if your package contains a C extension


### PR DESCRIPTION
The name of the branch in GA repo is `master`, not `main`.  :-(