### PR TITLE
run CI on pushes to main

### DIFF
--- a/.github/workflows/metrics_logger_ci.yml
+++ b/.github/workflows/metrics_logger_ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
because the CI does not trigger on pushes to the `main` branch, that coverage is not tracked